### PR TITLE
Associate an existing IP to the NAT gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This module creates the following resources in AWS:
 
 In addition, if NAT gateway is enabled:
 
-- an Elastic IP
+- an Elastic IP (optional)
 - a NAT gateway in one of the public subnets
 
 ## Usage example
@@ -59,6 +59,7 @@ module "network" {
     }
   ]
   enable_nat_gateway = true
+  nat_eip_allocation_id = "" # set an existing EIP's id, or an empty string to create a new EIP
 }
 
 ```

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,7 +59,12 @@ output "route_table_ids_private" {
   description = "The IDs of the route tables for private subnets"
 }
 
-output "nat_eip" {
-  value       = aws_eip.quortex.id
-  description = "The static Elastic IP created for Quortex cluster External NAT Gateway IP."
+output "nat_eip_id" {
+  value       = var.enable_nat_gateway ?  (var.nat_eip_allocation_id == "" ? aws_eip.quortex[0].id : var.nat_eip_allocation_id ) : ""
+  description = "The ID of the Elastic IP associated to the Quortex cluster External NAT Gateway IP."
+}
+
+output "nat_eip_address" {
+  value       = var.enable_nat_gateway ?  (var.nat_eip_allocation_id == "" ? aws_eip.quortex[0].public_ip : data.aws_eip.existing_eip[0].public_ip ) : ""
+  description = "The public address of the Elastic IP associated to the Quortex cluster External NAT Gateway IP."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,9 @@ variable "single_nat_gateway" {
   description = "Set to true if a common NAT Gateway should be used for all subnets"
   default     = true
 }
+
+variable "nat_eip_allocation_id" {
+  type        = string
+  description = "Allocation ID of an existing EIP that should be associated to the NAT gateway. Specify this ID if you want to associate an existing EIP to the NAT gateway. If not specified, a new EIP will be created and associated to the NAT gateway."
+  default     = ""
+}


### PR DESCRIPTION
In order to keep a constant IP address for outgoing traffic (allowing IP to be whitelisted), an existing EIP can now be associated to the NAT gateway.

+ address and EIP alloc ID added to output variables